### PR TITLE
release - fix renovate branch parsing

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -13,6 +13,7 @@ release:
     # RENOVATE_BRANCH is the renovate branch that is expected to get merged and trigger this target
     ARG --required RENOVATE_BRANCH
     LET os=${RENOVATE_BRANCH#renovate/}
+    SET os=${os#major-}
     # using a LET/SET in the target path does not work, use an ARG instead until it's fixed
     ARG OS=${os%-dind-image}
     BUILD --pass-args ./os/$OS+release


### PR DESCRIPTION
Sometimes the renovate branch name might be something like `renovate/major-ubuntu-20.04-dind-image`
so this would fix the removal of `major-` as well.