### PR TITLE
Downgrade alpine docker version to force renovate flow

### DIFF
--- a/os/alpine/Earthfile
+++ b/os/alpine/Earthfile
@@ -11,7 +11,7 @@ ARG --global OS_IMAGE=alpine
 # renovate: datasource=docker depName=alpine
 ARG --global OS_VERSION=3.19
 # renovate: datasource=repology depName=alpine_3_19/docker versioning=loose
-ARG --global DOCKER_VERSION=25.0.3-r1
+ARG --global DOCKER_VERSION=25.0.2-r0
 
 # DIR_PATH is set to that common targets can call os specific targets. It should match the directory name this Earthfile is located in
 ARG --global DIR_PATH=$OS_IMAGE


### PR DESCRIPTION
The flow would update the version again to what it is now and release the version.

This is just a workaround until we make it a bit easier to release manually if needed.

I expect the tests for this PR to fail since the downgraded version is no longer available for alpine 3.19.