### PR TITLE
renovate config - allows for multiple docker major version updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -133,5 +133,15 @@
       allowedVersions: "/^ubuntu-23\\.04-.*/",
       versioning: "regex:^(?<compatibility>.*)-(?<major>\\d+\\.\\d+)-docker-(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)-(?<revision>\\d+)$",
     },
+    {
+      // create PRs for multiple docker versions in case we're more than one major version behind
+      matchPackageNames: [
+        'docker/docker',
+      ],
+      matchDatasources: [
+        'github-releases',
+      ],
+      separateMultipleMajor: true,
+    },
   ],
 }


### PR DESCRIPTION
This should allow renovate to upgrade ubuntu:23.04 to docker 25.x which is the latest available for that distribution