### PR TITLE
Fix release target

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -13,6 +13,8 @@ release:
     # RENOVATE_BRANCH is the renovate branch that is expected to get merged and trigger this target
     ARG --required RENOVATE_BRANCH
     LET os=${RENOVATE_BRANCH#renovate/}
+    # remove major-XX- or major-
+    SET os=$(echo ${os#major-[[:digit:]]?-})
     SET os=${os#major-}
     # using a LET/SET in the target path does not work, use an ARG instead until it's fixed
     ARG OS=${os%-dind-image}


### PR DESCRIPTION
After allowing for multiple major branches, the branch name now includes the major version value,
so we need to remove it when trying to get the os name from the branch name upon release.